### PR TITLE
Update flock to version 0.3.0

### DIFF
--- a/flock.rb
+++ b/flock.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class Flock < Formula
   homepage 'https://github.com/discoteq/flock'
-  version '0.2.3'
+  version '0.3.0'
   url "https://github.com/discoteq/flock/releases/download/v#{version}/flock-#{version}.tar.xz"
-  sha256 '3233658199683c807c21b0ef0fc32246e420f2a6e48f7044d2ccb763ff320c70'
+  sha256 '5f2298dbaf39bc3708e54f32705addc3d70f9aa16202d46fc08316f1237892c6'
 
   def install
     system './configure', '--disable-debug',


### PR DESCRIPTION
I saw that version 0.3.0 was released but not available on homebrew. I am new to homebrew taps, I don't know if there are more things that need to be done, but this seemed to work for me.